### PR TITLE
Removed outputs from actions.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -23,7 +23,6 @@ inputs:
     description: 'Allows the default humanitec api to be overidden for testing.'
     required: false
     default: 'api.humanitec.io'
-outputs:
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Removed `outputs` property as a change in GitHub causes this to now fail the action.