### PR TITLE
Distinct dockerfile and context arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,14 @@ the following code should be used to pass it to the action:
 _Optional_ The name you want to refer to the image to in the Humanitec Platform. The id must be all lowercase letters,
 numbers and the "-" symbol. It cannot start or end with "-".
 
+### `file`
+_Optional_ A path to an alternative Dockerfile.
+
+### `context`
+_Optional_ Context path. Defaults to ".".
+
 ### `dockerfile`
-_Optional_ Directory containing the Dockerfile. Defaults to the root of repository.
+_Optional_ The same as `context`.
 
 ### `tag`
 _Optional_ Define your own tag for the docker image to be tagged with.

--- a/docker.js
+++ b/docker.js
@@ -23,14 +23,19 @@ function login(username, password, server) {
 /**
  * Builds the image described by the Dockerfile and tags it locally.
  * @param {string} tag - The local tag to use for the built image.
- * @param {string} dockefilePath - The path to the Dockerfile.
- *   (Can be a directory or the path to a file to use as Dockerfile.)
+ * @param {string} file - A path to an alternative dockerfile.
+ * @param {string} contextPath - A directory of a build's context.
  * @param {string} server - The host to connect to to log in.
  * @return {string} - The container ID assuming a successful build. falsy otherwise.
  */
-async function build(tag, dockefilePath) {
+async function build(tag, file, contextPath) {
   try {
-    await exec.exec('docker', ['build', '-t', tag, dockefilePath]);
+    let args = ['build', '-t', tag]
+    if(file != '') {
+      args.push('-f', file)
+    }
+    args.push(contextPath)
+    await exec.exec('docker', args);
 
     return cp.execSync(`docker images -q "${tag}"`).toString().trim();
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ async function runAction() {
   const token = core.getInput('humanitec-token', {required: true});
   const orgId = core.getInput('organization', {required: true});
   const imageName = core.getInput('image-name') || process.env.GITHUB_REPOSITORY.replace(/.*\//, '');
-  const dockerfile = core.getInput('dockerfile') || '.';
+  const context = core.getInput('dockerfile') || core.getInput('context') || '.';
+  const file = core.getImput('file') || '',
   const registryHost = core.getInput('humanitec-registry') || 'registry.humanitec.io';
   const apiHost = core.getInput('humanitec-api') || 'api.humanitec.io';
   const tag = core.getInput('tag') || '';
@@ -33,9 +34,15 @@ async function runAction() {
     return;
   }
 
-  if (!fs.existsSync(dockerfile)) {
-    core.error(`Cannot find Dockerfile at ${dockerfile}`);
-    core.setFailed('Cannot find Dockerfile.');
+  if (!fs.existsSync(file)) {
+    core.error(`Cannot find file ${file}`);
+    core.setFailed('Cannot find file.');
+    return;
+  }
+
+  if (!fs.existsSync(context)) {
+    core.error(`Context path does not exist: ${context}`);
+    core.setFailed('Context path does not exist.');
     return;
   }
 
@@ -67,7 +74,7 @@ async function runAction() {
     localTag = `${orgId}/${imageName}:${tag}`;
   }
 
-  const imageId = await docker.build(localTag, dockerfile);
+  const imageId = await docker.build(localTag, file, context);
   if (!imageId) {
     core.setFailed('Unable build image from Dockerfile.');
     return;


### PR DESCRIPTION
Purpose: To make it possible to specify Dockerfile which is not in the build context directory:
```
docker build [-f DOCKERFILE] PATH
```

Arguments:
`file` is a path of an alternative dockerfile, if not specified it's omitted.
`context` is a build's context path (PATH).
`dockerfile` - the same as `context` not to break current behaviour.
 