### PR TITLE
feat: allow to use an existing image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ the following code should be used to pass it to the action:
 
 _Optional_ The name you want to use in the Docker registry. The name can only contain lowercase letters, numbers, hyphens ("-"), and underscores ("_").
 
+### `existing-image`
+
+_Optional_ Use an existing image instead of building an image. The image name needs to include a tag or digest.
+
 ### `file`
 
 _Optional_ A path to an alternative Dockerfile.

--- a/action.yaml
+++ b/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: 'The name you want to refer to the image to in the Humanitec Platform.'
     required: false
     default: ''
+  existing-image:
+    description: 'Use an existing image instead of building an image. The image name needs to include a tag or digest.'
+    required: false
+    default: ''
   tag:
     description: 'Use tag when you want to bring your own tag.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -41085,6 +41085,7 @@ async function runAction() {
     const token = core.getInput('humanitec-token', { required: true });
     const orgId = core.getInput('organization', { required: true });
     const imageName = core.getInput('image-name') || (process.env.GITHUB_REPOSITORY || '').replace(/.*\//, '');
+    const existingImage = core.getInput('existing-image') || '';
     const context = core.getInput('context') || core.getInput('dockerfile') || '.';
     const file = core.getInput('file') || '';
     let registryHost = core.getInput('humanitec-registry') || 'registry.humanitec.io';
@@ -41138,17 +41139,31 @@ async function runAction() {
         version = commit;
     }
     const imageWithVersion = `${imageName}:${version}`;
-    const localTag = `${orgId}/${imageWithVersion}`;
-    const imageId = await docker.build(localTag, file, additionalDockerArguments, context);
-    if (!imageId) {
-        core.setFailed('Unable build image from Dockerfile.');
-        return;
+    let imageId;
+    if (existingImage) {
+        imageId = existingImage;
+    }
+    else {
+        const localTag = `${orgId}/${imageWithVersion}`;
+        imageId = await docker.build(localTag, file, additionalDockerArguments, context);
+        if (!imageId) {
+            core.setFailed('Unable build image from Dockerfile.');
+            return;
+        }
     }
     const remoteTag = `${registryHost}/${imageWithVersion}`;
-    const pushed = await docker.push(imageId, remoteTag);
-    if (!pushed) {
-        core.setFailed('Unable to push image to registry');
-        return;
+    if (existingImage !== remoteTag) {
+        if (existingImage.startsWith(registryHost)) {
+            core.setFailed(`The provided image seems to be already pushed, but the version tag is not matching.\n` +
+                `Expected: ${remoteTag}\n` +
+                `Provided: ${existingImage}`);
+            return;
+        }
+        const pushed = await docker.push(imageId, remoteTag);
+        if (!pushed) {
+            core.setFailed('Unable to push image to registry');
+            return;
+        }
     }
     const payload = {
         name: `${registryHost}/${imageName}`,


### PR DESCRIPTION
Allow to use an existing image instead of building one inside the action.

Fix https://github.com/humanitec/build-push-to-humanitec/issues/38