### PR TITLE
docs: dockerfile as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ _Optional_ Use an existing image instead of building an image. The image name ne
 
 ### `file`
 
-_Optional_ A path to an alternative Dockerfile.
+_Optional_ Name of the Dockerfile, defaults to `$context/Dockerfile`.
 
 ### `context`
 
-_Optional_ Context path. Defaults to ".".
+_Optional_ Build context path. Defaults to the root of repository.
 
-### `dockerfile`
+### `dockerfile` (deprecated)
 
-_Optional_ The same as `context`.
+_Optional_ The same as `context`, use `context` instead.
 
 ### `tag`
 

--- a/action.ts
+++ b/action.ts
@@ -17,7 +17,7 @@ export async function runAction() {
   const orgId = core.getInput('organization', {required: true});
   const imageName = core.getInput('image-name') || (process.env.GITHUB_REPOSITORY || '').replace(/.*\//, '');
   const existingImage = core.getInput('existing-image') || '';
-  const context = core.getInput('context') || core.getInput('dockerfile') || '.';
+  const context = core.getInput('dockerfile') || core.getInput('context') || '.';
   const file = core.getInput('file') || '';
   let registryHost = core.getInput('humanitec-registry') || 'registry.humanitec.io';
   const apiHost = core.getInput('humanitec-api') || 'api.humanitec.io';

--- a/action.yaml
+++ b/action.yaml
@@ -2,7 +2,8 @@ name: 'Build and Push to Humanitec'
 description: 'Builds a container image from a Dockerfile and then pushes it to the Humanitec registry and notifies the platform.'
 inputs:
   humanitec-token:
-    description: 'API Token provided when you add your ci pipline in the Humanitec platform.'
+    description: |
+      API Token provided when you add your ci pipline in the Humanitec platform.
     required: true
   organization:
     description: 'The name of the organization that the image will be built for.'
@@ -25,14 +26,15 @@ inputs:
     description: 'Use auto-tag when you want to push tags/release by their git name.'
     required: false
   dockerfile:
-    description: 'Directory containing the Dockerfile. Defaults to the root of repository. The same as "context"'
+    description: 'The same as "context".'
     required: false
-    default: '.'
+    deprecationMessage: 'Use "context" instead.'
   context:
     description: 'Build context path. Defaults to the root of repository.'
     required: false
+    default: '.'
   file:
-    description: 'A path to an alternative Dockerfile. Defaults to Dockerfile in the context path'
+    description: 'Name of the Dockerfile, defaults to `$context/Dockerfile`.'
     required: false
   additional-docker-arguments:
     description: 'Additional arguments for docker (e.g.,build arguments). Defaults to empty.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -26827,7 +26827,7 @@ async function runAction() {
     const orgId = core.getInput('organization', { required: true });
     const imageName = core.getInput('image-name') || (process.env.GITHUB_REPOSITORY || '').replace(/.*\//, '');
     const existingImage = core.getInput('existing-image') || '';
-    const context = core.getInput('context') || core.getInput('dockerfile') || '.';
+    const context = core.getInput('dockerfile') || core.getInput('context') || '.';
     const file = core.getInput('file') || '';
     let registryHost = core.getInput('humanitec-registry') || 'registry.humanitec.io';
     const apiHost = core.getInput('humanitec-api') || 'api.humanitec.io';


### PR DESCRIPTION
Mark `dockerfile` as deprecated, `context` should be used instead.