### PR TITLE
chore: use v2 inside the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to the action using a variable expansion. For example, if the token is store as 
 the following code should be used to pass it to the action:
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
@@ -47,25 +47,26 @@ _Optional_ The same as `context`, use `context` instead.
 _Optional_ Define your own tag for the docker image to be tagged with.
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
         tag: latest
 ```
+
 ### `ref`
 
 _Optional_ Define your own ref to be sent to Humanitec instead of GitHub action's GITHUB_REF.
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
         ref: refs/heads/main
 ```
 
-> **_NOTE:_**  For auto-deployment to work on GitHub action trigger: `on: pull_request`, set `ref: refs/pr_head/${{ github.event.pull_request.head.ref }}` 
+> **_NOTE:_**  For auto-deployment to work on GitHub action trigger: `on: pull_request`, set `ref: refs/pr_head/${{ github.event.pull_request.head.ref }}`
 
 ### `auto-tag`
 
@@ -73,7 +74,7 @@ _Optional_ Use `auto-tag` when you want to push tags/release by their git name (
 > **_CAUTION:_** Images produced by this feature can be overwritten by branches with the same name - without a way to restore.
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
@@ -86,7 +87,7 @@ _Optional_ Use `additional-docker-arguments` if you need to provide additional a
 > NOTE: You can provide multiple argument by placing them in one long list of commands, e.g., `--build-arg env1=value1 --build-arg env2=value2`.
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
@@ -95,10 +96,10 @@ _Optional_ Use `additional-docker-arguments` if you need to provide additional a
 
 ### `external-registry-url`
 
-_Optional_ Push the image to an external container registry. This registry does not need to be [registered with Humanitec](https://docs.humanitec.com/guides/connect-ci-setup/container-registries) and authentication needs to be done before calling this action (e.g. using workload identity). 
+_Optional_ Push the image to an external container registry. This registry does not need to be [registered with Humanitec](https://docs.humanitec.com/guides/connect-ci-setup/container-registries) and authentication needs to be done before calling this action (e.g. using workload identity).
 
 ```yaml
-    uses: humanitec/build-push-to-humanitec@v1
+    uses: humanitec/build-push-to-humanitec@v2
       with:
         humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
         organization: awesome-company
@@ -114,12 +115,11 @@ Will push the resulting image to `europe-west3-docker.pkg.dev/gcp-project/reposi
 ## Example usage
 
 ```yaml
-uses: humanitec/build-push-to-humanitec@v1
+uses: humanitec/build-push-to-humanitec@v2
   with:
     humanitec-token: ${{ secrets.HUMANITEC_TOKEN }}
     organization: awesome-company
 ```
-
 
 ## Development
 


### PR DESCRIPTION
[v2](https://github.com/humanitec/build-push-to-humanitec/releases/tag/v2.0.0) has been released that uses `node20` instead of `node16`. 

Update the README to use `@v2`.