### PR TITLE
feat: support multiplatform builds by delegating push to buildx

### DIFF
--- a/action.ts
+++ b/action.ts
@@ -110,16 +110,7 @@ export async function runAction() {
   }
 
   const remoteTag = `${registryHost}/${imageWithVersion}`;
-  if (existingImage !== remoteTag) {
-    if (existingImage.startsWith(registryHost)) {
-      core.setFailed(
-        `The provided image seems to be already pushed, but the version tag is not matching.\n` +
-          `Expected: ${remoteTag}\n` +
-          `Provided: ${existingImage}`,
-      );
-      return;
-    }
-
+  if (existingImage) {
     const pushed = await docker.push(imageId, remoteTag);
     if (!pushed) {
       core.setFailed("Unable to push image to registry");

--- a/action.ts
+++ b/action.ts
@@ -94,6 +94,14 @@ export async function runAction() {
   const remoteTag = `${registryHost}/${imageWithVersion}`;
 
   if (existingImage) {
+    if (existingImage.startsWith(registryHost)) {
+      core.setFailed(
+        `The provided image seems to be already pushed, but the version tag is not matching.\n` +
+          `Expected: ${remoteTag}\n` +
+          `Provided: ${existingImage}`,
+      );
+      return;
+    }
     const pushed = await docker.push(existingImage, remoteTag);
     if (!pushed) {
       core.setFailed("Unable to push image to registry");

--- a/action.ts
+++ b/action.ts
@@ -93,28 +93,19 @@ export async function runAction() {
   const imageWithVersion = `${imageName}:${version}`;
   const remoteTag = `${registryHost}/${imageWithVersion}`;
 
-  let imageId;
   if (existingImage) {
-    imageId = existingImage;
+    const pushed = await docker.push(existingImage, remoteTag);
+    if (!pushed) {
+      core.setFailed("Unable to push image to registry");
+      return;
+    }
   } else {
-    imageId = await docker.build(
+    await docker.build(
       remoteTag,
       file,
       additionalDockerArguments,
       context,
     );
-    if (!imageId) {
-      core.setFailed("Unable build image from Dockerfile.");
-      return;
-    }
-  }
-
-  if (existingImage) {
-    const pushed = await docker.push(imageId, remoteTag);
-    if (!pushed) {
-      core.setFailed("Unable to push image to registry");
-      return;
-    }
   }
 
   const artefactName = `${registryHost}/${imageName}`;

--- a/action.ts
+++ b/action.ts
@@ -100,12 +100,7 @@ export async function runAction() {
       return;
     }
   } else {
-    await docker.build(
-      remoteTag,
-      file,
-      additionalDockerArguments,
-      context,
-    );
+    await docker.build(remoteTag, file, additionalDockerArguments, context);
   }
 
   const artefactName = `${registryHost}/${imageName}`;

--- a/action.ts
+++ b/action.ts
@@ -91,14 +91,14 @@ export async function runAction() {
     version = commit;
   }
   const imageWithVersion = `${imageName}:${version}`;
+  const remoteTag = `${registryHost}/${imageWithVersion}`;
 
   let imageId;
   if (existingImage) {
     imageId = existingImage;
   } else {
-    const localTag = `${orgId}/${imageWithVersion}`;
     imageId = await docker.build(
-      localTag,
+      remoteTag,
       file,
       additionalDockerArguments,
       context,
@@ -109,7 +109,6 @@ export async function runAction() {
     }
   }
 
-  const remoteTag = `${registryHost}/${imageWithVersion}`;
   if (existingImage) {
     const pushed = await docker.push(imageId, remoteTag);
     if (!pushed) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -45193,19 +45193,18 @@ async function runAction() {
         version = commit;
     }
     const imageWithVersion = `${imageName}:${version}`;
+    const remoteTag = `${registryHost}/${imageWithVersion}`;
     let imageId;
     if (existingImage) {
         imageId = existingImage;
     }
     else {
-        const localTag = `${orgId}/${imageWithVersion}`;
-        imageId = await build(localTag, file, additionalDockerArguments, context);
+        imageId = await build(remoteTag, file, additionalDockerArguments, context);
         if (!imageId) {
             core.setFailed("Unable build image from Dockerfile.");
             return;
         }
     }
-    const remoteTag = `${registryHost}/${imageWithVersion}`;
     if (existingImage) {
         const pushed = await push(imageId, remoteTag);
         if (!pushed) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -45195,6 +45195,12 @@ async function runAction() {
     const imageWithVersion = `${imageName}:${version}`;
     const remoteTag = `${registryHost}/${imageWithVersion}`;
     if (existingImage) {
+        if (existingImage.startsWith(registryHost)) {
+            core.setFailed(`The provided image seems to be already pushed, but the version tag is not matching.\n` +
+                `Expected: ${remoteTag}\n` +
+                `Provided: ${existingImage}`);
+            return;
+        }
         const pushed = await push(existingImage, remoteTag);
         if (!pushed) {
             core.setFailed("Unable to push image to registry");

--- a/dist/index.js
+++ b/dist/index.js
@@ -45194,23 +45194,15 @@ async function runAction() {
     }
     const imageWithVersion = `${imageName}:${version}`;
     const remoteTag = `${registryHost}/${imageWithVersion}`;
-    let imageId;
     if (existingImage) {
-        imageId = existingImage;
-    }
-    else {
-        imageId = await build(remoteTag, file, additionalDockerArguments, context);
-        if (!imageId) {
-            core.setFailed("Unable build image from Dockerfile.");
-            return;
-        }
-    }
-    if (existingImage) {
-        const pushed = await push(imageId, remoteTag);
+        const pushed = await push(existingImage, remoteTag);
         if (!pushed) {
             core.setFailed("Unable to push image to registry");
             return;
         }
+    }
+    else {
+        await build(remoteTag, file, additionalDockerArguments, context);
     }
     const artefactName = `${registryHost}/${imageName}`;
     core.setOutput("image", remoteTag);

--- a/dist/index.js
+++ b/dist/index.js
@@ -27506,7 +27506,7 @@ const login = function (username, password, server) {
  */
 const build = async function (tag, file, additionalDockerArguments, contextPath) {
     try {
-        const args = ["buildx", "build", "-t", tag];
+        const args = ["buildx", "build", "-t", tag, "--load"];
         if (file != "") {
             args.push("-f", file);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -27506,7 +27506,7 @@ const login = function (username, password, server) {
  */
 const build = async function (tag, file, additionalDockerArguments, contextPath) {
     try {
-        const args = ["buildx", "build", "-t", tag, "--load"];
+        const args = ["buildx", "build", "-t", tag, "--push"];
         if (file != "") {
             args.push("-f", file);
         }
@@ -45206,13 +45206,7 @@ async function runAction() {
         }
     }
     const remoteTag = `${registryHost}/${imageWithVersion}`;
-    if (existingImage !== remoteTag) {
-        if (existingImage.startsWith(registryHost)) {
-            core.setFailed(`The provided image seems to be already pushed, but the version tag is not matching.\n` +
-                `Expected: ${remoteTag}\n` +
-                `Provided: ${existingImage}`);
-            return;
-        }
+    if (existingImage) {
         const pushed = await push(imageId, remoteTag);
         if (!pushed) {
             core.setFailed("Unable to push image to registry");

--- a/docker.ts
+++ b/docker.ts
@@ -39,7 +39,7 @@ export const build = async function (
   contextPath: string,
 ): Promise<string> {
   try {
-    const args = ["buildx", "build", "-t", tag];
+    const args = ["buildx", "build", "-t", tag, "--load"];
     if (file != "") {
       args.push("-f", file);
     }

--- a/docker.ts
+++ b/docker.ts
@@ -39,7 +39,7 @@ export const build = async function (
   contextPath: string,
 ): Promise<string> {
   try {
-    const args = ["buildx", "build", "-t", tag, "--load"];
+    const args = ["buildx", "build", "-t", tag, "--push"];
     if (file != "") {
       args.push("-f", file);
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     pool: "forks", // Required because the tests use chdir
     testTimeout: 50000, // Required because the tests are building and pushing images
-    hookTimeout: 30000,
+    hookTimeout: 50000,
   },
 });


### PR DESCRIPTION
This PR supports multi-platform builds by delegating the image push to the buildx build instruction (via the --push flag).

This allows to simplify the action quite a lot by also only pushing the image manually if the existing image was specified already. This avoids some of the additional checks.
