### PR TITLE
fix: 🐛 inline private workflow

### DIFF
--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -10,5 +10,17 @@ permissions:
 jobs:
   dependabot-auto-merge:
     name: 🔀 Auto-approve & merge
-    uses: humanitec/reusable-workflows/.github/workflows/dependabot-auto-merge.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && !github.event.pull_request.auto_merge }}
+    steps:
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously I set up this repo to use an internal workflow when a PR is opened for dependabot auto approves & merges. But public github repos cannot use private actions. We need to add a minimal version explicitly of the usual flow. 

We can also [tweak the workflow](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#access-to-reusable-workflows) to be accessible, but we have chosen to inline it instead [before](https://github.com/humanitec/humanitec-go-autogen).